### PR TITLE
Exit site building when an error occurs

### DIFF
--- a/src/django_amber/management/commands/buildsite.py
+++ b/src/django_amber/management/commands/buildsite.py
@@ -28,6 +28,7 @@ class Command(BaseCommand):
         shutil.rmtree(output_path, ignore_errors=True)
 
         for rsp in http_crawler.crawl('http://localhost:{}/'.format(port), follow_external_links=False):
+            rsp.raise_for_status()
             path = http_crawler.urlparse(rsp.url).path
             segments = path.split('/')
             assert segments[0] == ''

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -417,13 +417,14 @@ class TestBuildSite(TransactionTestCase):
         self.assertDirectoriesEqual('output', os.path.join('tests', 'expected-output'))
 
     @override_settings(DJANGO_AMBER_CNAME='amber.example.com')
+    @override_settings(DEBUG=True)  # This is required for static file handling
     def test_buildsite_with_cname(self):
         management.call_command('buildsite', verbosity=0)
         path = os.path.join('output', 'CNAME')
         with open(path) as f:
             self.assertEqual('amber.example.com', f.read())
 
-    @override_settings()
+    @override_settings(DEBUG=True)  # This is required for static file handling
     def test_buildsite_without_cname(self):
         del settings.DJANGO_AMBER_CNAME
         management.call_command('buildsite', verbosity=0)


### PR DESCRIPTION
By checking the status of the web crawler we can exit the build process early and avoid debug pages slipping into the built output.
